### PR TITLE
getItemCount before Cursor is swapped, or may end up in an inconsiste…

### DIFF
--- a/app/src/main/java/net/rymate/notes/data/CursorRecyclerAdapter.java
+++ b/app/src/main/java/net/rymate/notes/data/CursorRecyclerAdapter.java
@@ -144,6 +144,7 @@ public abstract class CursorRecyclerAdapter<VH
             if (mChangeObserver != null) oldCursor.unregisterContentObserver(mChangeObserver);
             if (mDataSetObserver != null) oldCursor.unregisterDataSetObserver(mDataSetObserver);
         }
+		int itemCount = getItemCount();
         mCursor = newCursor;
         if (newCursor != null) {
             if (mChangeObserver != null) newCursor.registerContentObserver(mChangeObserver);
@@ -157,7 +158,7 @@ public abstract class CursorRecyclerAdapter<VH
             mDataValid = false;
 // notify the observers about the lack of a data set
 // notifyDataSetInvalidated();
-            notifyItemRangeRemoved(0, getItemCount());
+            notifyItemRangeRemoved(0, itemCount);
         }
         return oldCursor;
     }


### PR DESCRIPTION
Copy result of getItemCount() before Cursor is swapped, or the Adapter may end up in an inconsistent state, triggering 'java.lang.IndexOutOfBoundsException: Inconsistency detected. Invalid view holder adapter positionViewHolder'. This bug would occur if I left a Fragment or Activity while RecyclerView was still populating the screen from the Adapter.
